### PR TITLE
OLMT modifications for modex_workshop

### DIFF
--- a/runcase.py
+++ b/runcase.py
@@ -683,6 +683,7 @@ print("CASE directory is: "+casedir)
 
 #Construct case build and run directory
 if (options.exeroot == '' or (os.path.exists(options.exeroot) == False)):
+    options.no_build=False
     exeroot = runroot+'/'+casename+'/bld'
     #if ('titan' in options.machine or 'eos' in options.machine):
     #    exeroot = os.path.abspath(os.environ['HOME']+ \

--- a/runcase.py
+++ b/runcase.py
@@ -1103,6 +1103,9 @@ if (options.ad_spinup):
     elif (options.mymodel == 'CLM5'):
         os.system('./xmlchange CLM_ACCELERATED_SPINUP=on')
         os.system('./xmlchange CLM_FORCE_COLDSTART=on')
+if (options.topounits_atmdownscale and options.mymodel == 'ELM'):
+    os.system("./xmlchange --append "+mylsm+"_BLDNML_OPTS='-topounit'")
+
 #if (options.use_hydrstress):
 #    os.system("./xmlchange --append "+mylsm+"_BLDNML_OPTS='-hydrstress'")
 
@@ -1466,8 +1469,13 @@ for i in range(1,int(options.ninst)+1):
 
     if (options.var_soilthickness):
         output.write(" use_var_soil_thick = .TRUE.\n")
-    if (options.topounits_atmdownscale):
-        output.write(" use_atm_downscaling_to_topunit = .true.\n")
+    #if (options.topounits_atmdownscale):
+    #    the following not works. Instead by appending "-topounit" into ELM_BLDNML_OPTS
+    #    output.write(" use_atm_downscaling_to_topunit = .true.\n")
+    if (options.topounits_atmdownscale or options.use_IM2_hillslope_hydrology):
+        # topounits included surface data, by default, separated 17 PFTs into 15 natpfts and 2 cfts.
+        # so have to switch on following namelist 
+        output.write(" create_crop_landunit = .true.\n")
     if (options.topounits_raddownscale):
         output.write(" use_top_solar_rad = .true.\n")
     if (options.no_budgets):

--- a/runcase.py
+++ b/runcase.py
@@ -357,8 +357,8 @@ parser.add_option("--var_list_pft", dest="var_list_pft", default="",help='Comma-
 # use topounit downscaling:
 parser.add_option("--topounits_atmdownscale", dest = "topounits_atmdownscale", default=False, \
                   help="Use atmospheric downscaling in topounits", action='store_true')
-parser.add_option("--topounits_raddownscale", dest = "topounits_raddownscale", default=False, \
-                  help="Downscale radiation input to topounits", action = "store_true")
+parser.add_option("--terrain_raddownscale", dest = "terrain_raddownscale", default=False, \
+                  help="cannopy/bare-ground top solar radiation downscaling based on terrain features", action = "store_true")
 # snow options:
 parser.add_option("--dust_snow_mixing", dest="dust_snow_mixing", default=False, \
                   help = "Use Hao et al. dust/snow mixing albedo parameterization", action="store_true")
@@ -1476,7 +1476,7 @@ for i in range(1,int(options.ninst)+1):
         # topounits included surface data, by default, separated 17 PFTs into 15 natpfts and 2 cfts.
         # so have to switch on following namelist 
         output.write(" create_crop_landunit = .true.\n")
-    if (options.topounits_raddownscale):
+    if (options.terrain_raddownscale):
         output.write(" use_top_solar_rad = .true.\n")
     if (options.no_budgets):
         output.write(" do_budgets = .false.\n")

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -269,8 +269,8 @@ parser.add_option("--use_firn_percolation_and_compaction ", dest = "use_firn_per
 #topounits
 parser.add_option("--topounits_atmdownscale", dest = "topounits_atmdownscale", default=False,
                   help="Use atmospheric downscaling in topounits", action='store_true')
-parser.add_option("--topounits_raddownscale", dest = "topounits_raddownscale", default=False,
-                  help="Use radiation downscaling in topounits", action='store_true')
+parser.add_option("--terrain_raddownscale", dest = "terrain_raddownscale", default=False,
+                  help="cannopy/bare-ground top solar radiation downscaling based on terrain features", action='store_true')
 # polygonal tundra:
 parser.add_option("--use_polygonal_tundra", dest="use_polygonal_tundra", default=False, \
                   help= "Turn on the polygonal tundra parameterizations, NGEE Arctic Phase 3 IM1", action="store_true")
@@ -751,8 +751,8 @@ for row in AFdatareader:
         # topounits
         if (options.topounits_atmdownscale):
             basecmd = basecmd + ' --topounits_atmdownscale'
-        if (options.topounits_raddownscale):
-            basecmd = basecmd + ' --topounits_raddownscale'
+        if (options.terrain_raddownscale):
+            basecmd = basecmd + ' --terrain_raddownscale'
         # polygonal tundra
         if (options.use_polygonal_tundra):
             basecmd = basecmd + ' --use_polygonal_tundra'

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -71,9 +71,9 @@ parser.add_option("--pio_version", dest="pio_version", default='2', \
                       help = "PIO version (1 or 2)")
 
 # CASE options
-parser.add_option("--nyears_ad_spinup", dest="ny_ad", default=250, \
+parser.add_option("--nyears_ad_spinup", dest="ny_ad", default=200, \
                   help = 'number of years to run ad_spinup')
-parser.add_option("--nyears_final_spinup", dest="nyears_final_spinup", default='200', \
+parser.add_option("--nyears_final_spinup", dest="nyears_final_spinup", default=600, \
                   help="base no. of years for final spinup")
 parser.add_option("--nyears_transient", dest="nyears_transient", default=-1, \
                   help = 'number of years to run transient')


### PR DESCRIPTION
Modifications of python scripts, runcase.py, site_fullrun.py, for using ELM namelists, use_atm_downscaling_to_topunit, use_IM2_hillslope_hydrology, and use_top_solar_rad. NOTE, global_run.py may be needed to modify as well (but not in this PR)